### PR TITLE
Fix various issues with the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "extension-template",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "dist/bundle.js",
   "scripts": {
     "start": "webpack-dev-server --hot --disable-host-check --port 8080",
     "start-no-hot": "webpack-dev-server --no-inline --no-hot --port 8080",
-    "build": "tsc --noEmit && webpack --mode=production",
+    "build": "export BABEL_ENV=build && tsc --noEmit && webpack --mode=production --config webpack.prod.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Looker",

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -22,47 +22,32 @@
  * THE SOFTWARE.
  */
 
-module.exports = api => {
-  api.cache(true)
+const path = require("path")
 
-  return {
-    presets: [
-      [
-        '@babel/env',
-        {
-          targets: {
-            browsers: 'Last 2 Chrome versions, Firefox ESR',
-            node: '8.9',
-          },
-        },
-      ],
-      [
-        '@babel/preset-react',
-        {
-          development: process.env.BABEL_ENV !== 'build',
-        },
-      ],
-      '@babel/preset-typescript',
-    ],
-    env: {
-      build: {
-        ignore: [
-          '**/*.d.ts',
-          '**/*.test.js',
-          '**/*.test.jsx',
-          '**/*.test.ts',
-          '**/*.test.tsx',
-          '__snapshots__',
-          '__tests__',
-        ],
+const PATHS = {
+  app: path.join(__dirname, 'src/index.tsx'),
+}
+
+module.exports = {
+  entry: {
+    app: PATHS.app,
+  },
+  output: {
+    path: __dirname + '/dist',
+    filename: 'bundle.js',
+  },
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        include: /src/
       },
-    },
-    ignore: ['node_modules'],
-    plugins: [
-      '@babel/plugin-proposal-class-properties',
-      '@babel/plugin-proposal-object-rest-spread',
-      '@babel/plugin-transform-runtime',
-      'babel-plugin-styled-components',
     ],
-  }
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
 }


### PR DESCRIPTION
1. production build was actually a dev build, now its production
2. hot reload module was included in prod build (only needed for dev)
3. babel react processor thought it was a dev build so included local file names.